### PR TITLE
fix state bug

### DIFF
--- a/library/src/main/java/com/kennyc/view/MultiStateView.java
+++ b/library/src/main/java/com/kennyc/view/MultiStateView.java
@@ -310,7 +310,7 @@ public class MultiStateView extends FrameLayout {
                 addView(mContentView);
                 break;
         }
-
+        setView();
         if (switchToState) setViewState(state);
     }
 


### PR DESCRIPTION
when in content state,
my code:

vConversationMsv.setViewForState(R.layout.layout_empty_weiliao, MultiStateView.VIEW_STATE_EMPTY);

then the MultiStateView shows content view &empty view .
add setView() after setViewForState() will fix this bug.
