### PR TITLE
The onRestoreInstanceState method is corrected.

### DIFF
--- a/library/src/main/java/com/kennyc/view/MultiStateView.java
+++ b/library/src/main/java/com/kennyc/view/MultiStateView.java
@@ -189,8 +189,8 @@ public class MultiStateView extends FrameLayout {
     @Override
     protected void onRestoreInstanceState(Parcelable state) {
         SavedState savedState = (SavedState) state;
-        setViewState(savedState.state);
         super.onRestoreInstanceState(savedState.getSuperState());
+        setViewState(savedState.state);
     }
 
     /**


### PR DESCRIPTION
It is more correct to call
super.onRestoreInstanceState(savedState.getSuperState());
first and restore our own state afterwards